### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,19 +1,5 @@
-# Netbeans
-/nbproject
-# PhpStorm
-/.idea
-
 # NPM, Bower, Gulp
 /node_modules
 /bower_components
 /.sass-cache
 npm-debug.log
-# Docker
-docker-compose.override.yaml
-
-###> symfony/webpack-encore-bundle ###
-/node_modules/
-/public/build/
-npm-debug.log
-yarn-error.log
-###< symfony/webpack-encore-bundle ###


### PR DESCRIPTION
- Les règles d'exclusions spécifiques à des IDE doivent être dans un fichier `.gitignore` global sur le poste du développeur
- La règle d'exclusion du `docker-compose.override.yaml` devrait également être dans un `.gitignore` global car c'est un besoin spécifique
- Les règles d'exclusions ajoutées par `symfony/webpack-encore-bundle` n'ont pas leur place ici car ce projet est framework-agnostic. De plus, ces règles seront de toute façon ajoutées par la recette Flex de `symfony/webpack-encore-bundle` lors de son installation